### PR TITLE
Fix not enforcing global seed overwrite when parsing parameters

### DIFF
--- a/cfDNA_GCcorrection/computeGCBias_background.py
+++ b/cfDNA_GCcorrection/computeGCBias_background.py
@@ -436,9 +436,11 @@ def tabulateGCcontent(
 @click.option(
     "--seed",
     "seed",
-    default=None,
+    default=42,
     type=click.INT,
-    help="""Set seed for reproducibility.""",
+    help="""Set seed for reproducibility. If not provided, 
+    will be set automatically, as a seed is needed to 
+    reproduce the regions in downstream analysis.""",
 )
 @click.option(
     "--mp_backend",
@@ -554,7 +556,7 @@ def main(
         seed=seed,
     )
 
-    sampleSize_regions = int(max(1,sampleSize / 1000))
+    sampleSize_regions = int(max(1, sampleSize / 1000))
     regions = random.sample(regions, sampleSize_regions)
 
     logger.debug(f"regions contains {len(regions)} genomic coordinates")

--- a/cfDNA_GCcorrection/computeGCBias_readlen.py
+++ b/cfDNA_GCcorrection/computeGCBias_readlen.py
@@ -852,6 +852,9 @@ def main(
             f"Overwriting the following options: genome, sampleSize, region and seed"
         )
         logger.debug(f"params: {regions_params}")
+        seed = regions_params["seed"]
+        rng = np.random.default_rng(seed=seed)
+        random.seed(seed)
         sampleSize = regions_params["nregions"]
         regions = get_regions(bam=bam, blacklist=blacklistfile, **regions_params)
     else:


### PR DESCRIPTION
Minor fixes:

computeGCBias_background.py:
- sets seed by default to ensure reproducibility for downstream analysis

computeGCBias_readlen.py:
- overwrites seed globally when parsing parameters from file