### PR TITLE
Develop

### DIFF
--- a/cfDNA_GCcorrection/cfDNA_GCcorrection_list_tools.py
+++ b/cfDNA_GCcorrection/cfDNA_GCcorrection_list_tools.py
@@ -3,7 +3,7 @@
 
 import argparse
 import sys
-from deeptools._version import __version__
+from cfDNA_GCcorrection._version import __version__
 
 
 def parse_arguments(args=None):
@@ -18,7 +18,7 @@ analysis and correction of GC bias in cfDNA sequencing data.
     computeGCBias_readlen           computes the length based GC bias of a sample
 
 
-[ Tools for BAM and bigWig file processing ]
+[ Tools for BAM file processing ]
     correctGCBias_readlen           corrects GC bias from bam file by attaching weight tags 
                                     or changing read copies. 
 

--- a/cfDNA_GCcorrection/computeGCBias_readlen.py
+++ b/cfDNA_GCcorrection/computeGCBias_readlen.py
@@ -505,11 +505,15 @@ def interpolate_ratio_csaps(df, smooth=None, normalized=False, minreads=4):
         x = i.tolist()
         scaling = scaling_dict[x[0]]
         if (N_f2(x)).astype(int) > minreads and (F_f2(x)).astype(int) > minreads:
-            ratio = int(F_f2(x)) / int(N_f2(x)) * scaling
+            ratio = int(F_f2(x).item()) / int(N_f2(x).item()) * scaling
         else:
             ratio = 1
-        f_list.append(int(F_f2(x)))
-        n_list.append(int(N_f2(x)))
+        f_int = int(F_f2(x).item())
+        n_int = int(N_f2(x).item())
+        f_list.append(f_int if f_int > 0 else 0)
+        n_list.append(n_int if n_int > 0 else 0)
+        #f_list.append(int(F_f2(x)))
+        #n_list.append(int(N_f2(x)))
         r_list.append(ratio)
 
     ratio_dense = np.array(r_list).reshape(N_a.shape).T

--- a/cfDNA_GCcorrection/computeGCBias_readlen.py
+++ b/cfDNA_GCcorrection/computeGCBias_readlen.py
@@ -656,6 +656,15 @@ def get_ratio(df, minreads=4):
             less accurate results. Deactivated by default.""",
 )
 @click.option(
+    "-ni",
+    "--normalized_interpolation",
+    "normalized_interpolation",
+    is_flag=True,
+    help="""Flag: option to normalize smooth parameters for interpolation. 
+            If active, interpolation results are invariant to xdata range and 
+            less sensitive to nonuniformity of weights and xdata clumping.""",
+)
+@click.option(
     "--minreads",
     "minreads",
     default=4,
@@ -745,6 +754,7 @@ def main(
     maxlen,
     lengthStep,
     interpolate,
+    normalized_interpolation,
     minreads,
     measurement_output,
     precomputed_Ngc,
@@ -909,7 +919,7 @@ def main(
         if measurement_output:
             logger.info("saving measured data")
             data.to_csv(measurement_output, sep="\t")
-        r_data = interpolate_ratio_csaps(data, minreads=minreads)
+        r_data = interpolate_ratio_csaps(data, minreads=minreads, normalized=normalized_interpolation)
         r_data.to_csv(gcbias_frequency_output, sep="\t")
     else:
         if measurement_output:

--- a/cfDNA_GCcorrection/computeGCBias_readlen.py
+++ b/cfDNA_GCcorrection/computeGCBias_readlen.py
@@ -512,9 +512,7 @@ def interpolate_ratio_csaps(df, smooth=None, normalized=False, minreads=4):
         n_int = int(N_f2(x).item())
         f_list.append(f_int if f_int > 0 else 0)
         n_list.append(n_int if n_int > 0 else 0)
-        #f_list.append(int(F_f2(x)))
-        #n_list.append(int(N_f2(x)))
-        r_list.append(ratio)
+        r_list.append(ratio if ratio > 0 else 1)
 
     ratio_dense = np.array(r_list).reshape(N_a.shape).T
     F_dense = np.array(f_list).reshape(N_a.shape).T


### PR DESCRIPTION
**Welcome to cfDNA_GCcorrection GitHub repository! Please check the following regarding
your pull request :**

 - [x] Does the PR contain new feature?
 - [x] Does the PR contain bugfix?

- Fixes some minor bugs in data handling during interpolation. The background and measured fragment distribution was filtered for Bias calculation, but not for reporting. This is now fixed. 
- Additionally, included a filter for GC bias values, which should never be negative.
- Add a CLI option to activate the normalized_interpolation option. This option activates [smooth-normalization](https://csaps.readthedocs.io/en/latest/tutorial.html#smooth-normalization), which normalizes parameters in a way that results are invariant to xdata range and less sensitive to nonuniformity of weights and xdata clumping.




